### PR TITLE
Improve logging output display

### DIFF
--- a/lib/graphConfig.js
+++ b/lib/graphConfig.js
@@ -34,7 +34,9 @@ function GraphConfig(config, properties) {
             v    = traversedConfig.get(path);
 
         if (typeof v === 'undefined') {
-            not_found.push(varName);
+            if (not_found.indexOf(varName) === -1) { // Don't push duplicate values into <not_found>
+              not_found.push(varName);
+            }
             return match;
         }
 
@@ -82,7 +84,7 @@ function GraphConfig(config, properties) {
             });
 
             if (not_found.length > 0) {
-                throw new Error(util.format('%d referenced variables were not found: %s', not_found.length, not_found.join(', ')));
+                throw new Error(util.format('%d referenced variables were not found:\n\t===> %s', not_found.length, not_found.join('\n\t===> ')));
             }
 
             if (!graphLib.alg.isAcyclic(graph)) {

--- a/lib/graphConfig.js
+++ b/lib/graphConfig.js
@@ -128,7 +128,7 @@ function GraphConfig(config, properties) {
             str =  str.replace(MULTI_REFERENCE_RegExp, sub);
 
             if (not_found.length > 0) {
-                throw new Error(util.format('%d referenced variables were not found: %s', not_found.length, not_found.join(', ')));
+                throw new Error(util.format('%d referenced variables were not found:\n\t===> %s', not_found.length, not_found.join('\n\t===> ')));
             }
 
             return str;


### PR DESCRIPTION
Improve the readability of missing property names, in addition to preventing duplicates from improperly inflating the `not_found` message.