### PR TITLE
Fix properties overwriting config values; add more tests.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,0 @@
-image: node
-git:
-  path: github.ibm.com/mhamann/node-configurator
-script:
-  - npm install
-  - npm test

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# IDE files
+.idea

--- a/lib/graphConfig.js
+++ b/lib/graphConfig.js
@@ -20,7 +20,10 @@ function GraphConfig(config, properties) {
 
 
     var init = function(config, props) {
-        config = assign(config, props);
+        config = assign(config, {
+            _properties: props
+        });
+
         traversedConfig = traverse(config);
     };
 
@@ -31,8 +34,15 @@ function GraphConfig(config, properties) {
     var sub = function (match, varName) {
 
         var path = varName.split('.'),
-            v    = traversedConfig.get(path);
+            // First check the config to see if we can find the value
+            v = traversedConfig.get(path);
 
+        if (typeof v === 'undefined') {
+            path.splice(0, 0, '_properties');
+            v = traversedConfig.get(path);
+        }
+
+		// Couldn't find the referenced value anywhere, so track the list
         if (typeof v === 'undefined') {
             if (not_found.indexOf(varName) === -1) { // Don't push duplicate values into <not_found>
               not_found.push(varName);
@@ -113,7 +123,7 @@ function GraphConfig(config, properties) {
         },
 
         getConfig: function() {
-            return omit(config, Object.keys(properties));
+            return omit(config, '_properties');
         },
 
         getStats: function() {
@@ -125,7 +135,7 @@ function GraphConfig(config, properties) {
 
         rawSubstitute: function(str) {
 
-            str =  str.replace(MULTI_REFERENCE_RegExp, sub);
+            str = str.replace(MULTI_REFERENCE_RegExp, sub);
 
             if (not_found.length > 0) {
                 throw new Error(util.format('%d referenced variables were not found:\n\t===> %s', not_found.length, not_found.join('\n\t===> ')));

--- a/test/graphConfig.js
+++ b/test/graphConfig.js
@@ -2,25 +2,78 @@ var GraphConfig = require('../lib/graphConfig');
 var test = require('tape');
 var fs = require('fs');
 var path = require('path');
+var assign = require('lodash.assign');
 var properties = require('properties');
 var nconf = require('nconf');
 
-nconf.file('base', __dirname + '/mocks/prod.json');
-nconf.file('prod', __dirname + '/mocks/base.json');
+var formats = {
+    '.properties' : {
+        parse: function(data) {
+            return properties.parse(data, {
+                'namespaces': true
+            });
+        },
+        stringify: properties.stringify
+    }
+};
 
-var baseConfig = nconf.get();
-delete baseConfig._;
-delete baseConfig.$0;
-var props = properties.parse(fs.readFileSync(__dirname + '/mocks/prod.properties', 'utf8'), { 'namespaces': true });
+function initConfigLayers(opts) {
+
+	var conf = new nconf.Provider();
+	var defaultPropFile = __dirname + '/mocks/prod.properties';
+
+	conf.file('base', __dirname + '/mocks/prod.json');
+	conf.file('prod', __dirname + '/mocks/base.json');
+	
+	var props = new nconf.Provider();
+	props.add(path.normalize(defaultPropFile), {
+		type: 'file',
+		file: path.normalize(defaultPropFile),
+		format: formats[path.extname(defaultPropFile)]   // Might be undefined, which is OK (defaults to .json)
+	});
+	
+	// Process additional config or properties files for a given test
+	if (opts && typeof opts.configFiles !== 'undefined') {
+		opts.configFiles.forEach(function(file) {
+			conf.file(path.basename(file), file);
+		});
+	}
+	
+	if (opts && typeof opts.propFiles !== 'undefined') {
+		opts.propFiles.forEach(function(file) {
+			props.add(path.normalize(file), {
+				type: 'file',
+				file: path.normalize(file),
+				format: formats[path.extname(file)]   // Might be undefined, which is OK (defaults to .json)
+			});
+		});
+	}	
+	
+	var baseConfig = conf.get();
+	delete baseConfig._;
+	delete baseConfig.$0;
+	
+	var baseProps = props.get();
+	delete baseProps._;
+	delete baseProps.$0;
+	
+	return {
+		config: baseConfig,
+		props: baseProps
+	}
+
+}
 
 test('build a config based on some properties', function(t) {
 
     t.plan(3);
 
     var config;
+    
+    var layers = initConfigLayers();
 
     try {
-        config = GraphConfig(baseConfig, props).build();
+        config = GraphConfig(layers.config, layers.props).build();
     } catch(ex) {
         t.fail('A problem occurred building the configuration');
         console.error(ex);
@@ -29,4 +82,48 @@ test('build a config based on some properties', function(t) {
     t.equal(config.env, 'prod');
     t.equal(config.services.database, 'appdb-prod.mycompany.com', 'config.services.database should === appdb-prod.mycompany.com');
     t.equal(config.db_config.password, 'myreallysecureprodpassword', 'config.db_config.password should === myreallysecureprodpassword');
+});
+
+test('throw an error if circular dependencies are found in config', function(t) {
+	
+	var config,
+		layers = initConfigLayers({
+			configFiles: [
+				__dirname + '/mocks/circular.json'
+			]
+		});
+		
+	try {
+		config = GraphConfig(layers.config, layers.props).build();
+		t.fail('Graph failed to catch circular references in config');
+	} catch(ex) {
+		t.pass('Circular references in config were caught');
+	}
+	
+	t.end();
+	
+});
+
+test('throw an error if circular dependencies are found between config and properties', function(t) {
+
+	var config,
+		layers = initConfigLayers({
+			configFiles: [
+				__dirname + '/mocks/config-prop-cycle.json'
+			],
+			
+			propFiles: [
+				__dirname + '/mocks/config-prop-cycle.properties'
+			]
+		});
+		
+	try {
+		config = GraphConfig(layers.config, layers.props).build();
+		t.fail('Graph failed to catch circular references between config and properties');
+	} catch(ex) {
+		t.pass('Circular references between config and properties were caught');
+	}
+	
+	t.end();
+
 });

--- a/test/graphConfig.js
+++ b/test/graphConfig.js
@@ -92,13 +92,12 @@ test('throw an error if circular dependencies are found in config', function(t) 
 				__dirname + '/mocks/circular.json'
 			]
 		});
-		
-	try {
-		config = GraphConfig(layers.config, layers.props).build();
-		t.fail('Graph failed to catch circular references in config');
-	} catch(ex) {
-		t.pass('Circular references in config were caught');
+
+	function buildConfig() {
+		GraphConfig(layers.config, layers.props).build()
 	}
+
+	t.throws(buildConfig, 'Circular reference exception thrown');
 	
 	t.end();
 	
@@ -116,13 +115,12 @@ test('throw an error if circular dependencies are found between config and prope
 				__dirname + '/mocks/config-prop-cycle.properties'
 			]
 		});
-		
-	try {
-		config = GraphConfig(layers.config, layers.props).build();
-		t.fail('Graph failed to catch circular references between config and properties');
-	} catch(ex) {
-		t.pass('Circular references between config and properties were caught');
+
+	function buildConfig() {
+		GraphConfig(layers.config, layers.props).build();
 	}
+
+	t.throws(buildConfig, 'Circular reference exception thrown');
 	
 	t.end();
 

--- a/test/mocks/circular.json
+++ b/test/mocks/circular.json
@@ -1,0 +1,9 @@
+{
+	"circular1": {
+		"key": "${circular2.key}"
+	},
+	
+	"circular2": {
+		"key": "${circular1.key}"
+	}
+}

--- a/test/mocks/config-prop-cycle.json
+++ b/test/mocks/config-prop-cycle.json
@@ -1,0 +1,5 @@
+{
+	"circularConfig": {
+		"key": "${circularProps.key}"
+	}
+}

--- a/test/mocks/config-prop-cycle.properties
+++ b/test/mocks/config-prop-cycle.properties
@@ -1,0 +1,1 @@
+circularProps.key = ${circularConfig.key}


### PR DESCRIPTION
In cases where a properties file was passed in having the same namespace as a portion of the config object, the underlying config values would be discarded.

Example:

```
base.json
-------------
{
    "section": {
        "key": "${section.propKey}"
    }
}
```

```
test.properties
-------------------
section.propKey = propValue
```

In this case, the resulting `section` object would be entirely missing due to the way the configuration was built.